### PR TITLE
hashObj() is too damn expensive

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,14 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  *
- * Copyright (c) 2017, Joyent, Inc.
+ * Copyright (c) 2018, Joyent, Inc.
  */
 
 var mod_assert = require('assert-plus');
 var mod_jsprim = require('jsprim');
 var VError = require('verror').VError;
-
-var mod_crypto = require('crypto');
 
 /*
  * This is a similar regex to the one used in the golang prometheus client lib.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,10 @@ function shallowClone(obj) {
 /*
  * To ensure that we don't store duplicate metrics, we must hash all of
  * the metrics before they're stored. This function takes an object of labels.
- * The labels are sorted alphabetically and sent through stringify.
+ * The labels are sorted alphabetically and returned as a string with the keys
+ * joined together (with no separator), the values joined together (with no
+ * separator) and the resulting two strings (keys and values) joined together
+ * with a '/' separator.
  */
 function hashObj(obj) {
     mod_assert.object(obj, 'obj');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,19 +37,22 @@ function shallowClone(obj) {
 /*
  * To ensure that we don't store duplicate metrics, we must hash all of
  * the metrics before they're stored. This function takes an object of labels.
- * The labels are sorted alphabetically, sent through stringify, and then their
- * md5 hash is calculated. This should be adequately unique for our case.
+ * The labels are sorted alphabetically and sent through stringify.
  */
 function hashObj(obj) {
     mod_assert.object(obj, 'obj');
 
-    var hash = mod_crypto.createHash('md5');
-    var newObj = {};
+    var idx;
     var keys = Object.keys(obj).sort();
-    keys.forEach(function (key) {
-        newObj[key] = obj[key];
-    });
-    return (hash.update(JSON.stringify(newObj)).digest('hex'));
+    var keysStr = '';
+    var values = '';
+
+    for (idx = 0; idx < keys.length; idx++) {
+        keysStr += keys[idx];
+        values += obj[keys[idx]];
+    }
+
+    return (keysStr + '/' + values);
 }
 
 /*


### PR DESCRIPTION
In my testing, a busy CNAPI (420~430 requests per second) is spending the largest share of its time in hashObj(). Replacing hashObj() with a version that's less expensive (the version in this PR):

 1. reduces user CPU usage (with the same load) from ~70% to ~46% for the CNAPI process.
 2. reduces the number of node GC (scavenge) executions from ~7/second to ~4/second
 3. reduces the percent of time node spends paused for GC from 5.4% to about 2.8%
 4. reduces the average time for a libuv eventloop from ~700 microseconds to ~330 microseconds

<img width="1194" alt="hashobj-zone-load-average" src="https://user-images.githubusercontent.com/78194/42430460-3843f00a-82f4-11e8-9ac6-9361622974e8.png">
<img width="1191" alt="hashobj-cpu-usage" src="https://user-images.githubusercontent.com/78194/42430461-386b0276-82f4-11e8-8465-d3a7d803f527.png">
<img width="1191" alt="hashobj-eventloop-avg-time" src="https://user-images.githubusercontent.com/78194/42430462-387fce54-82f4-11e8-9eeb-7cfef2828fa9.png">
<img width="1192" alt="hashobj-gc-pause-time" src="https://user-images.githubusercontent.com/78194/42430463-389469ae-82f4-11e8-91fb-ff7f13deb8ca.png">
<img width="1195" alt="hashobj-gc-count" src="https://user-images.githubusercontent.com/78194/42430464-38a95af8-82f4-11e8-839d-c1bbb884e628.png">
